### PR TITLE
Add basic auth scaffolding and roles

### DIFF
--- a/app/Http/Controllers/Auth/ForgotPasswordController.php
+++ b/app/Http/Controllers/Auth/ForgotPasswordController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Password;
+
+class ForgotPasswordController extends Controller
+{
+    public function create()
+    {
+        return view('auth.forgot-password');
+    }
+
+    public function store(Request $request)
+    {
+        $request->validate(['email' => ['required', 'email']]);
+
+        $status = Password::sendResetLink($request->only('email'));
+
+        return $status === Password::RESET_LINK_SENT
+                    ? back()->with('status', __($status))
+                    : back()->withErrors(['email' => __($status)]);
+    }
+}

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class LoginController extends Controller
+{
+    public function create()
+    {
+        return view('auth.login');
+    }
+
+    public function store(Request $request)
+    {
+        $credentials = $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required'],
+        ]);
+
+        if (Auth::attempt($credentials, $request->boolean('remember'))) {
+            $request->session()->regenerate();
+            return redirect()->intended('/');
+        }
+
+        return back()->withErrors([
+            'email' => __('auth.failed'),
+        ])->onlyInput('email');
+    }
+
+    public function destroy(Request $request)
+    {
+        Auth::logout();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+        return redirect('/');
+    }
+}

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Auth;
+
+class RegisterController extends Controller
+{
+    public function create()
+    {
+        return view('auth.register');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
+            'password' => ['required', 'confirmed'],
+        ]);
+
+        $user = User::create([
+            'name' => $data['name'],
+            'email' => $data['email'],
+            'password' => Hash::make($data['password']),
+            'role' => $request->input('role', 'user'),
+        ]);
+
+        Auth::login($user);
+
+        return redirect('/');
+    }
+}

--- a/app/Http/Controllers/Auth/ResetPasswordController.php
+++ b/app/Http/Controllers/Auth/ResetPasswordController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Password;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Auth\Events\PasswordReset;
+use Illuminate\Support\Str;
+
+class ResetPasswordController extends Controller
+{
+    public function create(string $token)
+    {
+        return view('auth.reset-password', ['token' => $token]);
+    }
+
+    public function store(Request $request)
+    {
+        $request->validate([
+            'token' => 'required',
+            'email' => 'required|email',
+            'password' => 'required|confirmed',
+        ]);
+
+        $status = Password::reset(
+            $request->only('email', 'password', 'password_confirmation', 'token'),
+            function ($user, $password) {
+                $user->forceFill([
+                    'password' => Hash::make($password),
+                    'remember_token' => Str::random(60),
+                ])->save();
+
+                event(new PasswordReset($user));
+            }
+        );
+
+        return $status == Password::PASSWORD_RESET
+            ? redirect()->route('login')->with('status', __($status))
+            : back()->withErrors(['email' => [__($status)]]);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -21,6 +21,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'role',
     ];
 
     /**

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -29,6 +29,8 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            // Rol por defecto para nuevos usuarios
+            'role' => 'user',
         ];
     }
 

--- a/database/migrations/0001_01_01_000003_add_role_to_users_table.php
+++ b/database/migrations/0001_01_01_000003_add_role_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('role')->default('user')->after('password');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('role');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,11 +13,7 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        // Ejecutar seeder de usuarios con roles
+        $this->call(UserSeeder::class);
     }
 }

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+use App\Models\User;
+
+class UserSeeder extends Seeder
+{
+    public function run(): void
+    {
+        User::factory()->create([
+            'name' => 'Administrador',
+            'email' => 'admin@example.com',
+            'password' => Hash::make('password'),
+            'role' => 'admin',
+        ]);
+
+        User::factory()->create([
+            'name' => 'Usuario',
+            'email' => 'user@example.com',
+            'password' => Hash::make('password'),
+            'role' => 'user',
+        ]);
+
+        User::factory()->count(3)->create();
+    }
+}

--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -1,0 +1,11 @@
+<x-layouts.guest>
+    <h1>Recuperar contraseña</h1>
+    <form method="POST" action="{{ route('password.email') }}">
+        @csrf
+        <div>
+            <label for="email">Correo</label>
+            <input id="email" type="email" name="email" required autofocus />
+        </div>
+        <button type="submit">Enviar enlace</button>
+    </form>
+</x-layouts.guest>

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,0 +1,21 @@
+<x-layouts.guest>
+    <h1>Iniciar sesión</h1>
+    <form method="POST" action="{{ route('login') }}">
+        @csrf
+        <div>
+            <label for="email">Correo</label>
+            <input id="email" type="email" name="email" required autofocus />
+        </div>
+        <div>
+            <label for="password">Contraseña</label>
+            <input id="password" type="password" name="password" required />
+        </div>
+        <div>
+            <label>
+                <input type="checkbox" name="remember"> Recordarme
+            </label>
+        </div>
+        <button type="submit">Entrar</button>
+    </form>
+    <a href="{{ route('password.request') }}">¿Olvidaste tu contraseña?</a>
+</x-layouts.guest>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,0 +1,23 @@
+<x-layouts.guest>
+    <h1>Registro de usuario</h1>
+    <form method="POST" action="{{ route('register') }}">
+        @csrf
+        <div>
+            <label for="name">Nombre</label>
+            <input id="name" type="text" name="name" required autofocus />
+        </div>
+        <div>
+            <label for="email">Correo</label>
+            <input id="email" type="email" name="email" required />
+        </div>
+        <div>
+            <label for="password">Contraseña</label>
+            <input id="password" type="password" name="password" required />
+        </div>
+        <div>
+            <label for="password_confirmation">Confirmar contraseña</label>
+            <input id="password_confirmation" type="password" name="password_confirmation" required />
+        </div>
+        <button type="submit">Registrar</button>
+    </form>
+</x-layouts.guest>

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -1,0 +1,20 @@
+<x-layouts.guest>
+    <h1>Restablecer contraseña</h1>
+    <form method="POST" action="{{ route('password.update') }}">
+        @csrf
+        <input type="hidden" name="token" value="{{ $token }}" />
+        <div>
+            <label for="email">Correo</label>
+            <input id="email" type="email" name="email" required autofocus />
+        </div>
+        <div>
+            <label for="password">Contraseña</label>
+            <input id="password" type="password" name="password" required />
+        </div>
+        <div>
+            <label for="password_confirmation">Confirmar contraseña</label>
+            <input id="password_confirmation" type="password" name="password_confirmation" required />
+        </div>
+        <button type="submit">Restablecer</button>
+    </form>
+</x-layouts.guest>

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,11 +4,31 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Admin\DashboardController;
 use App\Http\Controllers\Admin\UserController;
 use App\Http\Controllers\Admin\SettingsController;
+use App\Http\Controllers\Auth\LoginController;
+use App\Http\Controllers\Auth\RegisterController;
+use App\Http\Controllers\Auth\ForgotPasswordController;
+use App\Http\Controllers\Auth\ResetPasswordController;
 
 
 // Ruta principal de la aplicación
 Route::get('/', function () {
     return view('welcome');
+});
+
+// Autenticación básica
+Route::get('/login', [LoginController::class, 'create'])->name('login');
+Route::post('/login', [LoginController::class, 'store']);
+Route::post('/logout', [LoginController::class, 'destroy'])->name('logout');
+
+Route::get('/forgot-password', [ForgotPasswordController::class, 'create'])->name('password.request');
+Route::post('/forgot-password', [ForgotPasswordController::class, 'store'])->name('password.email');
+Route::get('/reset-password/{token}', [ResetPasswordController::class, 'create'])->name('password.reset');
+Route::post('/reset-password', [ResetPasswordController::class, 'store'])->name('password.update');
+
+// Registro solo accesible para usuarios autenticados (administradores)
+Route::middleware('auth')->group(function () {
+    Route::get('/register', [RegisterController::class, 'create'])->name('register');
+    Route::post('/register', [RegisterController::class, 'store']);
 });
 
 /*


### PR DESCRIPTION
## Summary
- add `role` column to users table
- add seeders with admin and user roles
- update User model and factory
- create auth controllers and views
- add auth routes

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_688522b620f4832ba8f6c4ae3240a906