### PR TITLE
Add dynamic CRUD generator module

### DIFF
--- a/app/Http/Controllers/Admin/DynamicCrudController.php
+++ b/app/Http/Controllers/Admin/DynamicCrudController.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\TablePermission;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Controlador para manejo dinámico de CRUD por tabla.
+ * Permite mostrar y modificar registros dependiendo de los permisos asignados
+ * mediante la tabla table_permissions.
+ */
+class DynamicCrudController extends Controller
+{
+    /**
+     * Muestra las tablas a las que el usuario tiene acceso de lectura.
+     */
+    public function index()
+    {
+        $userRoles = auth()->user()->roles->pluck('id');
+        $tables = TablePermission::whereIn('role_id', $userRoles)
+            ->where('can_view', true)
+            ->pluck('table_name')
+            ->unique();
+
+        return view('admin.dynamic-crud.index', compact('tables'));
+    }
+
+    /**
+     * Muestra el formulario para crear un nuevo registro en la tabla dada.
+     */
+    public function create(string $table)
+    {
+        $this->authorizeTable($table, 'can_create');
+        $columns = Schema::getColumnListing($table);
+        return view('admin.dynamic-crud.create', compact('table', 'columns'));
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(string $table, Request $request)
+    {
+        $this->authorizeTable($table, 'can_create');
+        $data = $request->except('_token');
+        DB::table($table)->insert($data);
+        return redirect()->route('admin.dynamic-crud.show', $table);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $table)
+    {
+        $this->authorizeTable($table, 'can_view');
+        $columns = Schema::getColumnListing($table);
+        $rows = DB::table($table)->paginate(15);
+        return view('admin.dynamic-crud.show', compact('table', 'columns', 'rows'));
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(string $table, $id)
+    {
+        $this->authorizeTable($table, 'can_update');
+        $columns = Schema::getColumnListing($table);
+        $row = DB::table($table)->where('id', $id)->first();
+        return view('admin.dynamic-crud.edit', compact('table', 'columns', 'row'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(string $table, $id, Request $request)
+    {
+        $this->authorizeTable($table, 'can_update');
+        $data = $request->except('_token', '_method');
+        DB::table($table)->where('id', $id)->update($data);
+        return redirect()->route('admin.dynamic-crud.show', $table);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $table, $id)
+    {
+        $this->authorizeTable($table, 'can_delete');
+        DB::table($table)->where('id', $id)->delete();
+        return redirect()->route('admin.dynamic-crud.show', $table);
+    }
+
+    /**
+     * Verifica que el usuario tenga permiso sobre la tabla indicada.
+     */
+    private function authorizeTable(string $table, string $action): void
+    {
+        $userRoles = auth()->user()->roles->pluck('id');
+        $permission = TablePermission::where('table_name', $table)
+            ->whereIn('role_id', $userRoles)
+            ->where($action, true)
+            ->exists();
+
+        abort_unless($permission, 403);
+    }
+}

--- a/app/Models/TablePermission.php
+++ b/app/Models/TablePermission.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Modelo que representa los permisos de acceso a cada tabla.
+ * Permite definir acciones permitidas por rol sobre tablas especificas.
+ */
+class TablePermission extends Model
+{
+    /**
+     * Atributos asignables de manera masiva.
+     */
+    protected $fillable = [
+        'table_name',
+        'role_id',
+        'can_view',
+        'can_create',
+        'can_update',
+        'can_delete',
+    ];
+}

--- a/config/permission.php
+++ b/config/permission.php
@@ -1,0 +1,207 @@
+<?php
+
+/**
+ * Configuracion del paquete Spatie Laravel Permission.
+ * Permite gestionar roles y permisos de forma flexible.
+ */
+
+return [
+
+    'models' => [
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * Eloquent model should be used to retrieve your permissions. Of course, it
+         * is often just the "Permission" model but you may use whatever you like.
+         *
+         * The model you want to use as a Permission model needs to implement the
+         * `Spatie\Permission\Contracts\Permission` contract.
+         */
+
+        'permission' => Spatie\Permission\Models\Permission::class,
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * Eloquent model should be used to retrieve your roles. Of course, it
+         * is often just the "Role" model but you may use whatever you like.
+         *
+         * The model you want to use as a Role model needs to implement the
+         * `Spatie\Permission\Contracts\Role` contract.
+         */
+
+        'role' => Spatie\Permission\Models\Role::class,
+
+    ],
+
+    'table_names' => [
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your roles. We have chosen a basic
+         * default value but you may easily change it to any table you like.
+         */
+
+        'roles' => 'roles',
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * table should be used to retrieve your permissions. We have chosen a basic
+         * default value but you may easily change it to any table you like.
+         */
+
+        'permissions' => 'permissions',
+
+        /*
+         * When using the "HasPermissions" trait from this package, we need to know which
+         * table should be used to retrieve your models permissions. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'model_has_permissions' => 'model_has_permissions',
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your models roles. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'model_has_roles' => 'model_has_roles',
+
+        /*
+         * When using the "HasRoles" trait from this package, we need to know which
+         * table should be used to retrieve your roles permissions. We have chosen a
+         * basic default value but you may easily change it to any table you like.
+         */
+
+        'role_has_permissions' => 'role_has_permissions',
+    ],
+
+    'column_names' => [
+        /*
+         * Change this if you want to name the related pivots other than defaults
+         */
+        'role_pivot_key' => null, // default 'role_id',
+        'permission_pivot_key' => null, // default 'permission_id',
+
+        /*
+         * Change this if you want to name the related model primary key other than
+         * `model_id`.
+         *
+         * For example, this would be nice if your primary keys are all UUIDs. In
+         * that case, name this `model_uuid`.
+         */
+
+        'model_morph_key' => 'model_id',
+
+        /*
+         * Change this if you want to use the teams feature and your related model's
+         * foreign key is other than `team_id`.
+         */
+
+        'team_foreign_key' => 'team_id',
+    ],
+
+    /*
+     * When set to true, the method for checking permissions will be registered on the gate.
+     * Set this to false if you want to implement custom logic for checking permissions.
+     */
+
+    'register_permission_check_method' => true,
+
+    /*
+     * When set to true, Laravel\Octane\Events\OperationTerminated event listener will be registered
+     * this will refresh permissions on every TickTerminated, TaskTerminated and RequestTerminated
+     * NOTE: This should not be needed in most cases, but an Octane/Vapor combination benefited from it.
+     */
+    'register_octane_reset_listener' => false,
+
+    /*
+     * Events will fire when a role or permission is assigned/unassigned:
+     * \Spatie\Permission\Events\RoleAttached
+     * \Spatie\Permission\Events\RoleDetached
+     * \Spatie\Permission\Events\PermissionAttached
+     * \Spatie\Permission\Events\PermissionDetached
+     *
+     * To enable, set to true, and then create listeners to watch these events.
+     */
+    'events_enabled' => false,
+
+    /*
+     * Teams Feature.
+     * When set to true the package implements teams using the 'team_foreign_key'.
+     * If you want the migrations to register the 'team_foreign_key', you must
+     * set this to true before doing the migration.
+     * If you already did the migration then you must make a new migration to also
+     * add 'team_foreign_key' to 'roles', 'model_has_roles', and 'model_has_permissions'
+     * (view the latest version of this package's migration file)
+     */
+
+    'teams' => false,
+
+    /*
+     * The class to use to resolve the permissions team id
+     */
+    'team_resolver' => \Spatie\Permission\DefaultTeamResolver::class,
+
+    /*
+     * Passport Client Credentials Grant
+     * When set to true the package will use Passports Client to check permissions
+     */
+
+    'use_passport_client_credentials' => false,
+
+    /*
+     * When set to true, the required permission names are added to exception messages.
+     * This could be considered an information leak in some contexts, so the default
+     * setting is false here for optimum safety.
+     */
+
+    'display_permission_in_exception' => false,
+
+    /*
+     * When set to true, the required role names are added to exception messages.
+     * This could be considered an information leak in some contexts, so the default
+     * setting is false here for optimum safety.
+     */
+
+    'display_role_in_exception' => false,
+
+    /*
+     * By default wildcard permission lookups are disabled.
+     * See documentation to understand supported syntax.
+     */
+
+    'enable_wildcard_permission' => false,
+
+    /*
+     * The class to use for interpreting wildcard permissions.
+     * If you need to modify delimiters, override the class and specify its name here.
+     */
+    // 'wildcard_permission' => Spatie\Permission\WildcardPermission::class,
+
+    /* Cache-specific settings */
+
+    'cache' => [
+
+        /*
+         * By default all permissions are cached for 24 hours to speed up performance.
+         * When permissions or roles are updated the cache is flushed automatically.
+         */
+
+        'expiration_time' => \DateInterval::createFromDateString('24 hours'),
+
+        /*
+         * The cache key used to store all permissions.
+         */
+
+        'key' => 'spatie.permission.cache',
+
+        /*
+         * You may optionally indicate a specific cache driver to use for permission and
+         * role caching using any of the `store` drivers listed in the cache.php config
+         * file. Using 'default' here means to use the `default` set in cache.php.
+         */
+
+        'store' => 'default',
+    ],
+];

--- a/database/migrations/2025_07_27_084939_create_table_permissions_table.php
+++ b/database/migrations/2025_07_27_084939_create_table_permissions_table.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Tabla intermedia para asignar permisos a las tablas de manera dinamica.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('table_permissions', function (Blueprint $table) {
+            $table->id();
+            $table->string('table_name');
+            $table->unsignedBigInteger('role_id');
+            $table->boolean('can_view')->default(true);
+            $table->boolean('can_create')->default(false);
+            $table->boolean('can_update')->default(false);
+            $table->boolean('can_delete')->default(false);
+            $table->timestamps();
+
+            $table->foreign('role_id')->references('id')->on('roles')->onDelete('cascade');
+            $table->unique(['table_name', 'role_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('table_permissions');
+    }
+};

--- a/database/migrations/2025_07_27_085039_create_permission_tables.php
+++ b/database/migrations/2025_07_27_085039_create_permission_tables.php
@@ -1,0 +1,140 @@
+<?php
+
+/**
+ * Migraciones base del paquete Spatie para roles y permisos.
+ */
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $teams = config('permission.teams');
+        $tableNames = config('permission.table_names');
+        $columnNames = config('permission.column_names');
+        $pivotRole = $columnNames['role_pivot_key'] ?? 'role_id';
+        $pivotPermission = $columnNames['permission_pivot_key'] ?? 'permission_id';
+
+        throw_if(empty($tableNames), new Exception('Error: config/permission.php not loaded. Run [php artisan config:clear] and try again.'));
+        throw_if($teams && empty($columnNames['team_foreign_key'] ?? null), new Exception('Error: team_foreign_key on config/permission.php not loaded. Run [php artisan config:clear] and try again.'));
+
+        Schema::create($tableNames['permissions'], static function (Blueprint $table) {
+            // $table->engine('InnoDB');
+            $table->bigIncrements('id'); // permission id
+            $table->string('name');       // For MyISAM use string('name', 225); // (or 166 for InnoDB with Redundant/Compact row format)
+            $table->string('guard_name'); // For MyISAM use string('guard_name', 25);
+            $table->timestamps();
+
+            $table->unique(['name', 'guard_name']);
+        });
+
+        Schema::create($tableNames['roles'], static function (Blueprint $table) use ($teams, $columnNames) {
+            // $table->engine('InnoDB');
+            $table->bigIncrements('id'); // role id
+            if ($teams || config('permission.testing')) { // permission.testing is a fix for sqlite testing
+                $table->unsignedBigInteger($columnNames['team_foreign_key'])->nullable();
+                $table->index($columnNames['team_foreign_key'], 'roles_team_foreign_key_index');
+            }
+            $table->string('name');       // For MyISAM use string('name', 225); // (or 166 for InnoDB with Redundant/Compact row format)
+            $table->string('guard_name'); // For MyISAM use string('guard_name', 25);
+            $table->timestamps();
+            if ($teams || config('permission.testing')) {
+                $table->unique([$columnNames['team_foreign_key'], 'name', 'guard_name']);
+            } else {
+                $table->unique(['name', 'guard_name']);
+            }
+        });
+
+        Schema::create($tableNames['model_has_permissions'], static function (Blueprint $table) use ($tableNames, $columnNames, $pivotPermission, $teams) {
+            $table->unsignedBigInteger($pivotPermission);
+
+            $table->string('model_type');
+            $table->unsignedBigInteger($columnNames['model_morph_key']);
+            $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_permissions_model_id_model_type_index');
+
+            $table->foreign($pivotPermission)
+                ->references('id') // permission id
+                ->on($tableNames['permissions'])
+                ->onDelete('cascade');
+            if ($teams) {
+                $table->unsignedBigInteger($columnNames['team_foreign_key']);
+                $table->index($columnNames['team_foreign_key'], 'model_has_permissions_team_foreign_key_index');
+
+                $table->primary([$columnNames['team_foreign_key'], $pivotPermission, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_permissions_permission_model_type_primary');
+            } else {
+                $table->primary([$pivotPermission, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_permissions_permission_model_type_primary');
+            }
+
+        });
+
+        Schema::create($tableNames['model_has_roles'], static function (Blueprint $table) use ($tableNames, $columnNames, $pivotRole, $teams) {
+            $table->unsignedBigInteger($pivotRole);
+
+            $table->string('model_type');
+            $table->unsignedBigInteger($columnNames['model_morph_key']);
+            $table->index([$columnNames['model_morph_key'], 'model_type'], 'model_has_roles_model_id_model_type_index');
+
+            $table->foreign($pivotRole)
+                ->references('id') // role id
+                ->on($tableNames['roles'])
+                ->onDelete('cascade');
+            if ($teams) {
+                $table->unsignedBigInteger($columnNames['team_foreign_key']);
+                $table->index($columnNames['team_foreign_key'], 'model_has_roles_team_foreign_key_index');
+
+                $table->primary([$columnNames['team_foreign_key'], $pivotRole, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_roles_role_model_type_primary');
+            } else {
+                $table->primary([$pivotRole, $columnNames['model_morph_key'], 'model_type'],
+                    'model_has_roles_role_model_type_primary');
+            }
+        });
+
+        Schema::create($tableNames['role_has_permissions'], static function (Blueprint $table) use ($tableNames, $pivotRole, $pivotPermission) {
+            $table->unsignedBigInteger($pivotPermission);
+            $table->unsignedBigInteger($pivotRole);
+
+            $table->foreign($pivotPermission)
+                ->references('id') // permission id
+                ->on($tableNames['permissions'])
+                ->onDelete('cascade');
+
+            $table->foreign($pivotRole)
+                ->references('id') // role id
+                ->on($tableNames['roles'])
+                ->onDelete('cascade');
+
+            $table->primary([$pivotPermission, $pivotRole], 'role_has_permissions_permission_id_role_id_primary');
+        });
+
+        app('cache')
+            ->store(config('permission.cache.store') != 'default' ? config('permission.cache.store') : null)
+            ->forget(config('permission.cache.key'));
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $tableNames = config('permission.table_names');
+
+        if (empty($tableNames)) {
+            throw new \Exception('Error: config/permission.php not found and defaults could not be merged. Please publish the package configuration before proceeding, or drop the tables manually.');
+        }
+
+        Schema::drop($tableNames['role_has_permissions']);
+        Schema::drop($tableNames['model_has_roles']);
+        Schema::drop($tableNames['model_has_permissions']);
+        Schema::drop($tableNames['roles']);
+        Schema::drop($tableNames['permissions']);
+    }
+};

--- a/resources/views/admin/dynamic-crud/create.blade.php
+++ b/resources/views/admin/dynamic-crud/create.blade.php
@@ -1,0 +1,21 @@
+{{-- Formulario para crear registros dinámicos --}}
+@extends('layouts.adminlte')
+@section('title', 'Crear en ' . $table)
+@section('content_header')
+    Nuevo registro en {{ $table }}
+@endsection
+@section('content')
+    <form action="{{ route('admin.dynamic-crud.store', $table) }}" method="POST">
+        @csrf
+        @foreach($columns as $col)
+            @if($col === 'id')
+                @continue
+            @endif
+            <div class="mb-3">
+                <label class="form-label">{{ $col }}</label>
+                <input type="text" name="{{ $col }}" class="form-control">
+            </div>
+        @endforeach
+        <button class="btn btn-primary" type="submit">Guardar</button>
+    </form>
+@endsection

--- a/resources/views/admin/dynamic-crud/edit.blade.php
+++ b/resources/views/admin/dynamic-crud/edit.blade.php
@@ -1,0 +1,22 @@
+{{-- Formulario para editar registros dinámicos --}}
+@extends('layouts.adminlte')
+@section('title', 'Editar en ' . $table)
+@section('content_header')
+    Editar registro
+@endsection
+@section('content')
+    <form action="{{ route('admin.dynamic-crud.update', [$table, $row->id]) }}" method="POST">
+        @csrf
+        @method('PUT')
+        @foreach($columns as $col)
+            @if($col === 'id')
+                @continue
+            @endif
+            <div class="mb-3">
+                <label class="form-label">{{ $col }}</label>
+                <input type="text" name="{{ $col }}" class="form-control" value="{{ $row->$col }}">
+            </div>
+        @endforeach
+        <button class="btn btn-primary" type="submit">Actualizar</button>
+    </form>
+@endsection

--- a/resources/views/admin/dynamic-crud/index.blade.php
+++ b/resources/views/admin/dynamic-crud/index.blade.php
@@ -1,0 +1,13 @@
+{{-- Vista de listado de tablas para CRUD dinámico --}}
+@extends('layouts.adminlte')
+@section('title', 'Tablas disponibles')
+@section('content_header')
+    Listado de tablas
+@endsection
+@section('content')
+    <ul>
+        @foreach($tables as $tbl)
+            <li><a href="{{ route('admin.dynamic-crud.show', $tbl) }}">{{ $tbl }}</a></li>
+        @endforeach
+    </ul>
+@endsection

--- a/resources/views/admin/dynamic-crud/show.blade.php
+++ b/resources/views/admin/dynamic-crud/show.blade.php
@@ -1,0 +1,37 @@
+{{-- Vista de filas de una tabla con opciones CRUD --}}
+@extends('layouts.adminlte')
+@section('title', 'Tabla ' . $table)
+@section('content_header')
+    Gestion de {{ $table }}
+@endsection
+@section('content')
+    <a href="{{ route('admin.dynamic-crud.create', $table) }}" class="btn btn-primary">Crear</a>
+    <table class="table table-striped mt-2">
+        <thead>
+            <tr>
+                @foreach($columns as $col)
+                    <th>{{ $col }}</th>
+                @endforeach
+                <th>Acciones</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($rows as $row)
+                <tr>
+                    @foreach($columns as $col)
+                        <td>{{ $row->$col }}</td>
+                    @endforeach
+                    <td>
+                        <a href="{{ route('admin.dynamic-crud.edit', [$table, $row->id]) }}" class="btn btn-sm btn-warning">Editar</a>
+                        <form action="{{ route('admin.dynamic-crud.destroy', [$table, $row->id]) }}" method="POST" style="display:inline-block;">
+                            @csrf
+                            @method('DELETE')
+                            <button class="btn btn-sm btn-danger" onclick="return confirm('¿Eliminar registro?')">Eliminar</button>
+                        </form>
+                    </td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+    {{ $rows->links() }}
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Admin\DashboardController;
 use App\Http\Controllers\Admin\UserController;
 use App\Http\Controllers\Admin\SettingsController;
+use App\Http\Controllers\Admin\DynamicCrudController;
 use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\Auth\RegisterController;
 use App\Http\Controllers\Auth\ForgotPasswordController;
@@ -305,6 +306,21 @@ Route::middleware(['auth', 'verified'])->prefix('admin')->name('admin.')->group(
         Route::get('/{project}', function ($project) {
             return view('admin.projects.show', compact('project'));
         })->name('show');
+    });
+
+    /*
+    |--------------------------------------------------------------------------
+    | Módulo CRUD Dinámico
+    |--------------------------------------------------------------------------
+    */
+    Route::prefix('tables')->name('dynamic-crud.')->group(function () {
+        Route::get('/', [DynamicCrudController::class, 'index'])->name('index');
+        Route::get('/{table}', [DynamicCrudController::class, 'show'])->name('show');
+        Route::get('/{table}/create', [DynamicCrudController::class, 'create'])->name('create');
+        Route::post('/{table}', [DynamicCrudController::class, 'store'])->name('store');
+        Route::get('/{table}/{id}/edit', [DynamicCrudController::class, 'edit'])->name('edit');
+        Route::put('/{table}/{id}', [DynamicCrudController::class, 'update'])->name('update');
+        Route::delete('/{table}/{id}', [DynamicCrudController::class, 'destroy'])->name('destroy');
     });
     
     /*

--- a/tests/Feature/DynamicCrudRoutesTest.php
+++ b/tests/Feature/DynamicCrudRoutesTest.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Pruebas para verificar las rutas del CRUD dinámico.
+ */
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class DynamicCrudRoutesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function index_requires_authentication()
+    {
+        $response = $this->get('/admin/tables');
+        $response->assertRedirect('/login');
+    }
+}


### PR DESCRIPTION
## Summary
- add model `TablePermission`
- integrate Spatie permission config and migrations
- implement `DynamicCrudController` with auth checks
- register new `tables` routes
- create blade views for dynamic CRUD
- add feature test for new routes

## Testing
- `composer test`
- `php artisan test --coverage` *(fails: Code coverage driver not available)*

------
https://chatgpt.com/codex/tasks/task_e_6885e7c1d0d4832b9401100b7056f46c