### PR TITLE
Estandarizar componentes AdminLTE

### DIFF
--- a/resources/views/components/adminlte/navbar.blade.php
+++ b/resources/views/components/adminlte/navbar.blade.php
@@ -1,4 +1,5 @@
 <!--begin::Header - Barra de navegación superior-->
+{{-- Componente reusable de barra de navegación --}}
 <nav class="app-header navbar navbar-expand bg-body">
     <!--begin::Container - Contenedor principal del navbar-->
     <div class="container-fluid">
@@ -206,3 +207,4 @@
     <!--end::Container-->
 </nav>
 <!--end::Header-->
+{{-- Fin del componente Navbar --}}

--- a/resources/views/components/adminlte/sidebar.blade.php
+++ b/resources/views/components/adminlte/sidebar.blade.php
@@ -1,4 +1,5 @@
 <!--begin::Sidebar-->
+{{-- Componente reusable de barra lateral --}}
 <aside class="app-sidebar bg-body-secondary shadow" data-bs-theme="dark">
     <!--begin::Sidebar Brand-->
     <div class="sidebar-brand">
@@ -52,3 +53,4 @@
     <!--end::Sidebar Wrapper-->
 </aside>
 <!--end::Sidebar-->
+{{-- Fin del componente Sidebar --}}

--- a/resources/views/layouts/adminlte.blade.php
+++ b/resources/views/layouts/adminlte.blade.php
@@ -1,4 +1,5 @@
 <!doctype html>
+{{-- Layout principal con AdminLTE integrado --}}
 <html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 <!--begin::Head-->
 <head>
@@ -68,11 +69,13 @@
     <div class="app-wrapper">
         
         <!--begin::Header-->
-        @include('components.adminlte.navbar')
+        {{-- Utilizamos el componente para facilitar su reutilización --}}
+        <x-admin-l-t-e-navbar />
         <!--end::Header-->
         
         <!--begin::Sidebar-->
-        @include('components.adminlte.sidebar')
+        {{-- Componente de menú lateral modular --}}
+        <x-admin-l-t-e-sidebar />
         <!--end::Sidebar-->
         
         <!--begin::App Main-->


### PR DESCRIPTION
## Summary
- integrar comentarios en español en archivos de layout y componentes
- usar `<x-admin-l-t-e-navbar />` y `<x-admin-l-t-e-sidebar />` en el layout principal

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6885ff587484832bb6752d3d6471f780