### PR TITLE
Implementación de Soft Deletes y factories para modelos

### DIFF
--- a/app/Models/ActivityLog.php
+++ b/app/Models/ActivityLog.php
@@ -2,6 +2,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 /**
  * Registro de actividades de usuarios
@@ -9,7 +10,9 @@ use Illuminate\Database\Eloquent\Model;
  */
 class ActivityLog extends Model
 {
-    protected $fillable = [
+    use HasFactory;
+
+    protected array $fillable = [
         'user_id',
         'method',
         'url',

--- a/app/Models/TablePermission.php
+++ b/app/Models/TablePermission.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 /**
  * Modelo que representa los permisos de acceso a cada tabla.
@@ -10,10 +11,12 @@ use Illuminate\Database\Eloquent\Model;
  */
 class TablePermission extends Model
 {
+    use HasFactory;
+
     /**
      * Atributos asignables de manera masiva.
      */
-    protected $fillable = [
+    protected array $fillable = [
         'table_name',
         'role_id',
         'can_view',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,18 +7,19 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Spatie\Permission\Traits\HasRoles;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, Notifiable, HasRoles;
+    use HasFactory, Notifiable, HasRoles, SoftDeletes;
 
     /**
      * Atributos que se pueden asignar de forma masiva.
      *
      * @var list<string>
      */
-    protected $fillable = [
+    protected array $fillable = [
         'name',
         'email',
         'password',
@@ -30,7 +31,7 @@ class User extends Authenticatable
      *
      * @var list<string>
      */
-    protected $hidden = [
+    protected array $hidden = [
         'password',
         'remember_token',
     ];

--- a/database/factories/ActivityLogFactory.php
+++ b/database/factories/ActivityLogFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ActivityLog;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ActivityLogFactory extends Factory
+{
+    protected $model = ActivityLog::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'method' => $this->faker->randomElement(['GET', 'POST', 'PUT', 'DELETE']),
+            'url' => $this->faker->url(),
+            'ip_address' => $this->faker->ipv4(),
+            'user_agent' => $this->faker->userAgent(),
+            'payload' => [],
+        ];
+    }
+}

--- a/database/factories/RoleFactory.php
+++ b/database/factories/RoleFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Spatie\Permission\Models\Role;
+
+class RoleFactory extends Factory
+{
+    protected $model = Role::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->unique()->word(),
+            'guard_name' => 'web',
+        ];
+    }
+}

--- a/database/factories/TablePermissionFactory.php
+++ b/database/factories/TablePermissionFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\TablePermission;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Spatie\Permission\Models\Role;
+
+class TablePermissionFactory extends Factory
+{
+    protected $model = TablePermission::class;
+
+    public function definition(): array
+    {
+        return [
+            'table_name' => $this->faker->word(),
+            'role_id' => Role::factory(),
+            'can_view' => true,
+            'can_create' => $this->faker->boolean(),
+            'can_update' => $this->faker->boolean(),
+            'can_delete' => $this->faker->boolean(),
+        ];
+    }
+}

--- a/database/migrations/2025_07_27_090002_add_soft_deletes_to_users_table.php
+++ b/database/migrations/2025_07_27_090002_add_soft_deletes_to_users_table.php
@@ -1,0 +1,27 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Agregar soporte para soft deletes en la tabla de usuarios.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Revertir la migración.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};


### PR DESCRIPTION
## Resumen
- se tiparon propiedades en modelos Eloquent
- `User` ahora utiliza `SoftDeletes`
- se añadieron factories para `ActivityLog`, `TablePermission` y `Role`
- nueva migración para soft deletes en `users`

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_688602345a54832bab093025edebbf82