### PR TITLE
Mejoras en controladores

### DIFF
--- a/app/Http/Controllers/Admin/ActivityLogController.php
+++ b/app/Http/Controllers/Admin/ActivityLogController.php
@@ -10,7 +10,10 @@ use App\Models\ActivityLog;
  */
 class ActivityLogController extends Controller
 {
-    public function index()
+    /**
+     * Muestra la bitácora de actividades.
+     */
+    public function __invoke()
     {
         $logs = ActivityLog::with('user')->latest()->paginate(20);
         return view('admin.logs.index', compact('logs'));

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -4,6 +4,8 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Models\User;
+use App\Http\Requests\StoreUserRequest;
+use App\Http\Requests\UpdateUserRequest;
 use Illuminate\Http\Request;
 
 /**
@@ -34,10 +36,10 @@ class UserController extends Controller
     /**
      * Guarda un nuevo usuario en la base de datos.
      */
-    public function store(Request $request)
+    public function store(StoreUserRequest $request)
     {
-        // Validar y crear usuario
-        // User::create($request->all());
+        // Crear usuario con datos validados
+        // User::create($request->validated());
         return redirect()->route('admin.users.index');
     }
 
@@ -60,9 +62,9 @@ class UserController extends Controller
     /**
      * Actualiza la información del usuario en la base de datos.
      */
-    public function update(Request $request, User $user)
+    public function update(UpdateUserRequest $request, User $user)
     {
-        // $user->update($request->all());
+        // $user->update($request->validated());
         return redirect()->route('admin.users.index');
     }
 

--- a/app/Http/Requests/StoreUserRequest.php
+++ b/app/Http/Requests/StoreUserRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreUserRequest extends FormRequest
+{
+    /**
+     * Determina si el usuario está autorizado para realizar esta solicitud.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Obtiene las reglas de validación que se aplican a la solicitud.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'email', 'max:255', 'unique:users,email'],
+            'password' => ['required', 'string', 'min:8', 'confirmed'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateUserRequest.php
+++ b/app/Http/Requests/UpdateUserRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateUserRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        $userId = $this->route('user')?->id;
+
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => [
+                'required',
+                'email',
+                'max:255',
+                Rule::unique('users', 'email')->ignore($userId),
+            ],
+            'password' => ['nullable', 'string', 'min:8', 'confirmed'],
+        ];
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -311,7 +311,7 @@ Route::middleware(['auth', 'verified'])->prefix('admin')->name('admin.')->group(
 
     // Bitácora de actividad (solo super admin o compliance)
     Route::prefix('logs')->name('logs.')->middleware('role:super-admin|compliance')->group(function () {
-        Route::get('/', [ActivityLogController::class, 'index'])->name('index');
+        Route::get('/', ActivityLogController::class)->name('index');
     });
 
     /*


### PR DESCRIPTION
## Resumen
- Convertido `ActivityLogController` a controlador invocable
- Añadidas `StoreUserRequest` y `UpdateUserRequest` para validar usuarios
- Actualizados métodos `store` y `update` de `UserController`
- Ajustada ruta de bitácora para usar el controlador invocable

## Testing
- `composer install --no-progress`
- `php artisan test --testsuite Feature --stop-on-failure`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_688602555de8832b83cd867a575a9c3c