### PR TITLE
Add settings management

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,15 @@ Esta aplicación es un **sistema de administración completo** que integra **Lar
 
 #### **Modelos y Base de Datos**
 - **Modelo User** con roles y permisos
+- **Modelo Setting** para configuraciones del sistema
 - **Migraciones**:
   - `create_users_table`: Tabla principal de usuarios
+  - `create_settings_table`: Configuraciones generales
   - `add_role_to_users_table`: Sistema de roles integrado
   - Sesiones y tokens de recuperación de contraseña
 - **Seeders**:
   - `UserSeeder`: Usuarios por defecto (admin y usuario estándar)
+  - `SettingSeeder`: Valores base de configuración
   - `DatabaseSeeder`: Configuración inicial de la base de datos
 
 #### **Vistas y Componentes**

--- a/app/Http/Controllers/Admin/SettingsController.php
+++ b/app/Http/Controllers/Admin/SettingsController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\Request;
+use App\Models\Setting;
 
 /**
  * Controlador encargado de la configuración general del sistema.
@@ -15,7 +16,8 @@ class SettingsController extends Controller
      */
     public function index()
     {
-        return view('admin.settings.index');
+        $settings = Setting::all()->pluck('value', 'key');
+        return view('admin.settings.index', compact('settings'));
     }
 
     public function general()
@@ -40,7 +42,10 @@ class SettingsController extends Controller
 
     public function updateGeneral(Request $request)
     {
-        return redirect()->back();
+        foreach ($request->only(['site_name', 'maintenance_mode']) as $key => $value) {
+            Setting::updateOrCreate(['key' => $key], ['value' => $value]);
+        }
+        return redirect()->back()->with('status', 'Configuración actualizada');
     }
 
     public function updateSecurity(Request $request)

--- a/app/Http/Requests/StoreUserRequest.php
+++ b/app/Http/Requests/StoreUserRequest.php
@@ -25,6 +25,7 @@ class StoreUserRequest extends FormRequest
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'email', 'max:255', 'unique:users,email'],
             'password' => ['required', 'string', 'min:8', 'confirmed'],
+            'role' => ['required', 'exists:roles,name'],
         ];
     }
 }

--- a/app/Http/Requests/UpdateUserRequest.php
+++ b/app/Http/Requests/UpdateUserRequest.php
@@ -28,6 +28,7 @@ class UpdateUserRequest extends FormRequest
                 Rule::unique('users', 'email')->ignore($userId),
             ],
             'password' => ['nullable', 'string', 'min:8', 'confirmed'],
+            'role' => ['required', 'exists:roles,name'],
         ];
     }
 }

--- a/app/Models/ActivityLog.php
+++ b/app/Models/ActivityLog.php
@@ -12,7 +12,7 @@ class ActivityLog extends Model
 {
     use HasFactory;
 
-    protected array $fillable = [
+    protected $fillable = [
         'user_id',
         'method',
         'url',

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+/**
+ * Modelo para guardar configuraciones clave/valor del sistema.
+ */
+class Setting extends Model
+{
+    use HasFactory;
+
+    /**
+     * Atributos asignables de forma masiva.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'key',
+        'value',
+    ];
+}

--- a/app/Models/TablePermission.php
+++ b/app/Models/TablePermission.php
@@ -16,7 +16,7 @@ class TablePermission extends Model
     /**
      * Atributos asignables de manera masiva.
      */
-    protected array $fillable = [
+    protected $fillable = [
         'table_name',
         'role_id',
         'can_view',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -19,7 +19,7 @@ class User extends Authenticatable
      *
      * @var list<string>
      */
-    protected array $fillable = [
+    protected $fillable = [
         'name',
         'email',
         'password',
@@ -30,7 +30,7 @@ class User extends Authenticatable
      *
      * @var list<string>
      */
-    protected array $hidden = [
+    protected $hidden = [
         'password',
         'remember_token',
     ];

--- a/config/menu.php
+++ b/config/menu.php
@@ -23,5 +23,11 @@ return [
             'route' => 'admin.logs.index',
             'permission' => 'view logs',
         ],
+        [
+            'title' => 'Configuración',
+            'icon' => 'bi bi-gear',
+            'route' => 'admin.settings.index',
+            'permission' => 'manage settings',
+        ],
     ],
 ];

--- a/database/migrations/2025_07_27_111424_create_settings_table.php
+++ b/database/migrations/2025_07_27_111424_create_settings_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->text('value')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('settings');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -18,5 +18,8 @@ class DatabaseSeeder extends Seeder
 
         // Ejecutar seeder de usuarios con roles
         $this->call(UserSeeder::class);
+
+        // Valores de configuración por defecto
+        $this->call(SettingSeeder::class);
     }
 }

--- a/database/seeders/RolePermissionSeeder.php
+++ b/database/seeders/RolePermissionSeeder.php
@@ -13,7 +13,7 @@ class RolePermissionSeeder extends Seeder
 {
     public function run(): void
     {
-        $permissions = ['manage users', 'view logs'];
+        $permissions = ['manage users', 'view logs', 'manage settings'];
         foreach ($permissions as $perm) {
             Permission::firstOrCreate(['name' => $perm]);
         }
@@ -24,7 +24,7 @@ class RolePermissionSeeder extends Seeder
         $user = Role::firstOrCreate(['name' => 'user']);
 
         $super->syncPermissions($permissions);
-        $admin->syncPermissions(['manage users']);
+        $admin->syncPermissions(['manage users', 'manage settings']);
         $compliance->syncPermissions(['view logs']);
     }
 }

--- a/database/seeders/SettingSeeder.php
+++ b/database/seeders/SettingSeeder.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class SettingSeeder extends Seeder
+{
+    /**
+     * Insert default application settings.
+     */
+    public function run(): void
+    {
+        \App\Models\Setting::updateOrCreate(
+            ['key' => 'site_name'],
+            ['value' => 'AdminLTE App']
+        );
+
+        \App\Models\Setting::updateOrCreate(
+            ['key' => 'maintenance_mode'],
+            ['value' => 'off']
+        );
+    }
+}

--- a/resources/views/admin/settings/index.blade.php
+++ b/resources/views/admin/settings/index.blade.php
@@ -4,5 +4,22 @@
     Configuración general
 @endsection
 @section('content')
-    <p>Página de ajustes del sistema.</p>
+    <form action="{{ route('admin.settings.general.update') }}" method="POST" class="w-50">
+        @csrf
+        <div class="mb-3">
+            <label class="form-label">Nombre del sitio</label>
+            <input type="text" name="site_name" class="form-control" value="{{ $settings['site_name'] ?? '' }}">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Modo mantenimiento</label>
+            <select name="maintenance_mode" class="form-select">
+                <option value="off" {{ ($settings['maintenance_mode'] ?? 'off') == 'off' ? 'selected' : '' }}>Off</option>
+                <option value="on" {{ ($settings['maintenance_mode'] ?? '') == 'on' ? 'selected' : '' }}>On</option>
+            </select>
+        </div>
+        <button class="btn btn-primary" type="submit">Guardar</button>
+    </form>
+    @if(session('status'))
+        <div class="alert alert-success mt-3">{{ session('status') }}</div>
+    @endif
 @endsection

--- a/resources/views/components/adminlte/navbar.blade.php
+++ b/resources/views/components/adminlte/navbar.blade.php
@@ -153,7 +153,7 @@
                              class="rounded-circle shadow" 
                              alt="Imagen de Usuario">
                         <p>
-                            {{ Auth::user()->name ?? 'Usuario' }} - {{ Auth::user()->role ?? 'Administrador' }}
+                            {{ Auth::user()->name ?? 'Usuario' }} - {{ Auth::user()->roles->pluck('name')->implode(', ') ?: 'Administrador' }}
                             <small>Miembro desde {{ Auth::user()->created_at ? Auth::user()->created_at->format('M. Y') : 'Nov. 2023' }}</small>
                         </p>
                     </li>

--- a/tests/Feature/SettingsTest.php
+++ b/tests/Feature/SettingsTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Setting;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SettingsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function admin_can_update_settings(): void
+    {
+        $this->seed(\Database\Seeders\RolePermissionSeeder::class);
+        $admin = User::factory()->create();
+        $admin->assignRole('admin');
+
+        $this->actingAs($admin);
+
+        $response = $this->post(route('admin.settings.general.update'), [
+            'site_name' => 'My Site',
+            'maintenance_mode' => 'on',
+        ]);
+
+        $response->assertRedirect();
+        $this->assertDatabaseHas('settings', ['key' => 'site_name', 'value' => 'My Site']);
+    }
+}

--- a/tests/Feature/UserRolesTest.php
+++ b/tests/Feature/UserRolesTest.php
@@ -26,8 +26,8 @@ class UserRolesTest extends TestCase
         $response = $this->post(route('admin.users.store'), [
             'name' => 'Usuario Prueba',
             'email' => 'test@example.com',
-            'password' => 'secret',
-            'password_confirmation' => 'secret',
+            'password' => 'secretpwd',
+            'password_confirmation' => 'secretpwd',
             'role' => 'admin',
         ]);
 


### PR DESCRIPTION
## Summary
- introduce `Setting` model and migration
- seed default settings and roles for management
- enhance settings controller to persist changes
- link settings screen in menu configuration
- cover basic settings update in tests

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_688606afd5b0832bb1fa2c2638244c9f